### PR TITLE
Wc + move logic from CatCommand to interface

### DIFF
--- a/src/main/kotlin/ru/hse/command/CatCommand.kt
+++ b/src/main/kotlin/ru/hse/command/CatCommand.kt
@@ -2,18 +2,15 @@ package ru.hse.command
 
 import ru.hse.executable.Executable
 import ru.hse.executable.ExecutionResult
-import ru.hse.utils.writeln
 import java.io.*
-import kotlin.io.path.Path
-import kotlin.io.path.isReadable
-import kotlin.io.path.isRegularFile
-import kotlin.io.path.notExists
 
-class CatCommand(private val arguments: List<String>) : Executable {
+class CatCommand(private val arguments: List<String>) : IOCommand, Executable {
+    override val commandName: String = "cat"
+
     override fun run(input: InputStream, output: OutputStream, error: OutputStream): ExecutionResult {
         return when {
             arguments.isEmpty() -> processEmptyArgumentList(input, output, error)
-            else -> processNotEmptyArgumentList(input, output, error)
+            else -> processNotEmptyArgumentList(output, error)
         }
     }
 
@@ -22,78 +19,23 @@ class CatCommand(private val arguments: List<String>) : Executable {
         output: OutputStream,
         error: OutputStream
     ): ExecutionResult {
-        try {
-            input.transferTo(output)
-        } catch (e: IOException) {
-            error.writeIOError(e.message)
-            return ExecutionResult.fail()
+        return if (safeIO(error) { input.transferTo(output) }) {
+            ExecutionResult.success()
+        } else {
+            ExecutionResult.fail()
         }
-        return ExecutionResult.success()
     }
 
     private fun processNotEmptyArgumentList(
-        ignored: InputStream,
         output: OutputStream,
         error: OutputStream
     ): ExecutionResult {
         var isSuccessful = true
         for (fileName in arguments) {
-            val fileValidationResult = checkFile(fileName, error)
-            if (!fileValidationResult) {
+            if (!readFile(fileName, error) { it.transferTo(output) }) {
                 isSuccessful = false
-                continue
-            }
-            @Suppress("SwallowedException")
-            try {
-                File(fileName).inputStream().buffered().use {
-                    it.transferTo(output)
-                }
-            } catch (e: SecurityException) {
-                isSuccessful = false
-                error.writePermissionDeniedError(fileName)
-            } catch (e: FileNotFoundException) {
-                isSuccessful = false
-                error.writeIsNotFileError(fileName)
-            } catch (e: IOException) {
-                isSuccessful = false
-                error.writeIOError(e.message)
             }
         }
         return if (isSuccessful) ExecutionResult.success() else ExecutionResult.fail()
-    }
-
-    private fun checkFile(fileName: String, error: OutputStream): Boolean {
-        val pathToFile = Path(fileName)
-        return when {
-            pathToFile.notExists() -> {
-                error.writeNotExistsError(fileName)
-                false
-            }
-            !pathToFile.isRegularFile() -> {
-                error.writeIsNotFileError(fileName)
-                false
-            }
-            !pathToFile.isReadable() -> {
-                error.writePermissionDeniedError(fileName)
-                false
-            }
-            else -> true
-        }
-    }
-
-    private fun OutputStream.writeIsNotFileError(fileName: String) {
-        writeln("cat: $fileName: Is not a regular file")
-    }
-
-    private fun OutputStream.writeNotExistsError(fileName: String) {
-        writeln("cat: $fileName: No such file or directory")
-    }
-
-    private fun OutputStream.writePermissionDeniedError(fileName: String) {
-        writeln("cat: $fileName: Permission denied")
-    }
-
-    private fun OutputStream.writeIOError(message: String?) {
-        writeln("cat: IO problem: $message")
     }
 }

--- a/src/main/kotlin/ru/hse/command/IOCommand.kt
+++ b/src/main/kotlin/ru/hse/command/IOCommand.kt
@@ -1,0 +1,94 @@
+package ru.hse.command
+
+import ru.hse.utils.writeln
+import java.io.*
+import kotlin.io.path.Path
+import kotlin.io.path.isReadable
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.notExists
+
+/**
+ * Команда, которая будет работать с вводом/выводом
+ */
+interface IOCommand {
+    /**
+     * Имя команды, которое будет использоваться при выводе ошибок
+     */
+    val commandName: String
+
+    /**
+     * Безопасно прочитать файл. Выводит ошибку в error, если она случилась во время чтения
+     * @return true, если чтение завершилось без ошибок
+     */
+    fun readFile(fileName: String, error: OutputStream, block: (InputStream) -> Unit): Boolean {
+        if (!checkFile(fileName, error)) {
+            return false
+        }
+        @Suppress("SwallowedException")
+        return try {
+            File(fileName).inputStream().buffered().use {
+                block(it)
+            }
+            true
+        } catch (e: SecurityException) {
+            error.writePermissionDeniedError(fileName)
+            false
+        } catch (e: FileNotFoundException) {
+            error.writeIsNotFileError(fileName)
+            false
+        } catch (e: IOException) {
+            error.writeIOError(e.message)
+            false
+        }
+    }
+
+    /**
+     * Безопасно выполнить IO действия
+     * Если во время исполнения произошло IOException, ошибка будет выведена в error
+     * @return true, если выполнение завершилось без ошибок
+     */
+    fun safeIO(error: OutputStream, block: () -> Unit): Boolean {
+        return try {
+            block()
+            true
+        } catch (e: IOException) {
+            error.writeIOError(e.message)
+            false
+        }
+    }
+
+    private fun checkFile(fileName: String, error: OutputStream): Boolean {
+        val pathToFile = Path(fileName)
+        return when {
+            pathToFile.notExists() -> {
+                error.writeNotExistsError(fileName)
+                false
+            }
+            !pathToFile.isRegularFile() -> {
+                error.writeIsNotFileError(fileName)
+                false
+            }
+            !pathToFile.isReadable() -> {
+                error.writePermissionDeniedError(fileName)
+                false
+            }
+            else -> true
+        }
+    }
+
+    private fun OutputStream.writeIsNotFileError(fileName: String) {
+        writeln("$commandName: $fileName: Is not a regular file")
+    }
+
+    private fun OutputStream.writeNotExistsError(fileName: String) {
+        writeln("$commandName: $fileName: No such file or directory")
+    }
+
+    private fun OutputStream.writePermissionDeniedError(fileName: String) {
+        writeln("$commandName: $fileName: Permission denied")
+    }
+
+    private fun OutputStream.writeIOError(message: String?) {
+        writeln("$commandName: IO problem: $message")
+    }
+}

--- a/src/main/kotlin/ru/hse/command/WcCommand.kt
+++ b/src/main/kotlin/ru/hse/command/WcCommand.kt
@@ -31,7 +31,7 @@ class WcCommand(private val args: List<String>, private val padding: Int = DEFAU
         input: InputStream,
         output: OutputStream,
         error: OutputStream,
-        metricBuilder: () -> WcCommand.InputStreamMetric
+        metricBuilder: () -> InputStreamMetric
     ): ExecutionResult {
         val success = safeIO(error) {
             val metric = metricBuilder()
@@ -44,7 +44,7 @@ class WcCommand(private val args: List<String>, private val padding: Int = DEFAU
     private fun processNotEmptyArgumentList(
         output: OutputStream,
         error: OutputStream,
-        metricBuilder: () -> WcCommand.InputStreamMetric
+        metricBuilder: () -> InputStreamMetric
     ): ExecutionResult {
         var allSuccessful = true
         val totalResults: MetricResults = TreeMap()
@@ -77,15 +77,15 @@ class WcCommand(private val args: List<String>, private val padding: Int = DEFAU
         fun allMeasurementsResult(): R
     }
 
-    private interface Metric<I, R, A> : AllMeasurementsResultsContainer<A> {
+    private interface Metric<I, R> {
         fun measure(input: I): R
     }
 
-    private interface InputStreamMetric : Metric<InputStream, MetricResults, Unit> {
-        override fun allMeasurementsResult() {}
-    }
+    private interface InputStreamMetric : Metric<InputStream, MetricResults>
 
-    private interface IterativeMetric<T> : Metric<T, Unit, MetricResults> {
+    private interface IterativeMetric<T> :
+        Metric<T, Unit>,
+        AllMeasurementsResultsContainer<MetricResults> {
         fun name(): MetricName
         fun value(): Long
 

--- a/src/main/kotlin/ru/hse/command/WcCommand.kt
+++ b/src/main/kotlin/ru/hse/command/WcCommand.kt
@@ -162,21 +162,26 @@ class WcCommand(private val args: List<String>, private val padding: Int = DEFAU
 
     private class LineCountMetric(
         private var lineCount: Long = 0,
-        private var prevCharacter: Int? = null
     ) : IterativeMetric<Int> {
+        private val whitespaceCharsArray = lineSeparator().toCharArray()
+        private val buffer = CharArray(whitespaceCharsArray.size)
+
         override fun measure(input: Int) {
-            val charsBuffer = StringBuilder()
-            prevCharacter?.let { charsBuffer.appendCodePoint(it) }
-            charsBuffer.appendCodePoint(input)
-            if (charsBuffer.toString().endsWith(lineSeparator())) {
+            for (i in 0 until buffer.size - 1) {
+                buffer[i] = buffer[i + 1]
+            }
+            buffer[buffer.lastIndex] = input.toChar()
+            if (isNewLine()) {
                 lineCount += 1
             }
-            prevCharacter = input
         }
 
         override fun name() = MetricName.Lines
-
         override fun value() = lineCount
+
+        private fun isNewLine(): Boolean {
+            return whitespaceCharsArray.contentEquals(buffer)
+        }
     }
 
     private class WordCountMetric(

--- a/src/test/kotlin/ru/hse/command/WcCommandTest.kt
+++ b/src/test/kotlin/ru/hse/command/WcCommandTest.kt
@@ -129,7 +129,14 @@ class WcCommandTest {
         val res = cat.run(input, output, error)
         assertFalse(res.needExit)
         assertNotEquals(0, res.exitCode)
-        assertEquals("       1       2       $file1BytesSize $file1${lineSeparator()}", output.toString(charset))
+        assertEquals(
+            """
+                |       1       2       $file1BytesSize $file1
+                |       1       2       $file1BytesSize total
+
+            """.trimMarginCrossPlatform(),
+            output.toString(charset)
+        )
         assertEquals(
             "wc: ${unreadable.path}: Permission denied${lineSeparator()}",
             error.toString(charset)

--- a/src/test/kotlin/ru/hse/command/WcCommandTest.kt
+++ b/src/test/kotlin/ru/hse/command/WcCommandTest.kt
@@ -173,9 +173,9 @@ class WcCommandTest {
     }
 
     companion object {
-        val file1: String = File("src/test/resources/wc.txt").path
+        const val file1: String = "src/test/resources/wc.txt"
         val file1BytesSize = File(file1).readBytes().size
-        private val file2 = File("src/test/resources/wc2.txt").path
+        private const val file2 = "src/test/resources/wc2.txt"
         private val file2BytesSize = File(file2).readBytes().size
 
         @JvmStatic


### PR DESCRIPTION
Я вынес из CatCommand полезные методы для IO в интерфейс и отнаследовал WcCommand от него.

Убрал флаги, но вроде бы их легко будет добавить обратно, просто вернув первые строчки метода run, чтобы buildMetrics возвращала нужные метрики

Изменил evaluateMetric на processNotEmptyArgumentList по аналогии с CatCommand

Изменил ByteProcessingInputStream, как писал в ПР

А так вроде ничего больше не изменилось

Также убрал, что Metric наследуется от AllMeasurementsResultsContainer: не понятно, почему должно быть наследование + приходилось писать пустое тело метода у InputStreamMetric, что наводит на мысли, что Metric не должен наследоваться

Изменил LineCountMetric, чтобы не создавать на каждую букву по объекту